### PR TITLE
Enable singleton processing when the game is paused

### DIFF
--- a/yandex_sdk.gd
+++ b/yandex_sdk.gd
@@ -50,6 +50,7 @@ var payload: String = ""
 
 
 func _ready() -> void:
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	if is_working():
 		get_window().focus_entered.connect(_update_mute)
 		get_window().focus_exited.connect(_update_mute)


### PR DESCRIPTION
Every node, including this plugin's singleton is effectively using `process_mode = Node.PROCESS_MODE_PAUSABLE` by default. That means the SDK integration will not work when the game is paused. For example, if you pause the game to show a fullscreen ad, the `interstitial_ad` signal will never be emitted and the ad will never be served. 

This is a one-line fix. :D