### PR TITLE
Fix leaderboards

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -94,7 +94,7 @@ Send request for get player's numeric data, when done emit **signal stats_loaded
 * **keys**: array, the list of keys to return.
 
 ### Initialize Leaderboards
-
+> ⚠️ **Deprecated**: This method has been deprecated, you no longer need to call this method to work with leaderboards
 ```gdscript
 YandexSDK.init_leaderboard() -> void
 ```

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ YandexSDK.load_stats(keys: Array) -> void
 * **keys**: список ключей, которые необходимо вернуть.
 
 ### Инициализация лидербордов
-
+> ⚠️ **Deprecated**: Этот метод устарел, теперь не нужно вызывать этот метод для работы с лидербордами
 ```gdscript
 YandexSDK.init_leaderboard() -> void
 ```

--- a/yandex_sdk.gd
+++ b/yandex_sdk.gd
@@ -36,7 +36,6 @@ var payload: String = ""
 
 @onready var callback_game_initialized = JavaScriptBridge.create_callback(_game_initialized)
 @onready var callback_player_initialized = JavaScriptBridge.create_callback(_player_initialized)
-@onready var callback_leaderboard_initialized = JavaScriptBridge.create_callback(_leaderboard_initialized)
 
 @onready var callback_rewarded_ad = JavaScriptBridge.create_callback(_rewarded_ad)
 @onready var callback_ad = JavaScriptBridge.create_callback(_interstitial_ad)
@@ -100,13 +99,15 @@ func _is_authorized(answer) -> void:
 	is_authorized = answer[0]
 	check_auth.emit(is_authorized)
 
+## устаревший метод
 func init_leaderboard() -> void:
 	if not OS.has_feature("yandex"):
 		return
 	if not is_leaderboard_initialization_started:
 		is_leaderboard_initialization_started = true
 		await game_initialized
-		window.InitLeaderboard(callback_leaderboard_initialized)
+		# window.InitLeaderboard(callback_leaderboard_initialized)
+		_leaderboard_initialized(args) # что бы игра не зависала на методе init_leaderboard в ожидании ответа
 
 func init_game() -> void:
 	if not OS.has_feature("yandex"):

--- a/yandex_sdk.js
+++ b/yandex_sdk.js
@@ -68,25 +68,8 @@ function GameplayStopped() {
 }
 
 // Leader boards
-var lb;
-function InitLeaderboard(callback) {
-	console.log("Leaderboard start initialization");
-	ysdk
-		.getLeaderboards()
-		.then((_lb) => {
-			lb = _lb;
-			console.log("Leaderboard initialized");
-
-			callback();
-		})
-		.catch((err) => {
-			console.log(err);
-			console.log("Leaderboard initialization error");
-		});
-}
-
 function GetLeaderboardDescription(leaderboardName, callback) {
-	lb.getLeaderboardDescription(leaderboardName).then(
+	ysdk.leaderboards.getDescription(leaderboardName).then(
 		(result) => {
 			console.log("Leaderboard description:");
 			console.log(result);
@@ -121,13 +104,13 @@ function SaveLeaderboardScore(leaderboardName, score, extraData) {
 		"with",
 		extraData,
 	);
-	lb.setLeaderboardScore(leaderboardName, score, extraData).then(() => {
+	ysdk.leaderboards.setScore(leaderboardName, score, extraData).then(() => {
 		console.log("Leaderboard score saved");
 	});
 }
 
 function LoadLeaderboardPlayerEntry(leaderboardName, callback) {
-	lb.getLeaderboardPlayerEntry(leaderboardName)
+	ysdk.leaderboards.getPlayerEntry(leaderboardName)
 		.then((res) => {
 			console.log("Loader leaderboard player entry:", res);
 			callback("loaded", res);
@@ -147,7 +130,7 @@ function LoadLeaderboardEntries(
 	quantityTop,
 	callback,
 ) {
-	lb.getLeaderboardEntries(leaderboardName, {
+	ysdk.leaderboards.getEntries(leaderboardName, {
 		includeUser: includeUser,
 		quantityAround: quantityAround,
 		quantityTop: quantityTop,


### PR DESCRIPTION
После обновлений моя игра стала виснуть на моменте загрузки, она застревала на инициализации лидербордов.  Yandex обновил методы для работы с лидербордами и удалил метод для инициализации лидербордов.
Я изменил методы в .js файле на новые и сделал обратную совместимость в методе `init_leaderboard`, теперь метод сразу вызывает сигнал `signal leaderboard_initialized()`. Так же в докуменатции метод для инициализации помечен как устаревший.